### PR TITLE
Improve Alert Management with Configurable Modes and Scheduled Execution

### DIFF
--- a/CollectStats_Loop.sh
+++ b/CollectStats_Loop.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Path of executable script
+
+EXECUTABLE ="CollectCDCStats.sh"
+
+# Delay in seconds between each run
+
+DELAY =5
+
+cleanup() {
+
+	echo ""
+	echo "Interrupted by user (Ctrl+C). Exiting gracefully..."
+	exit 0
+}
+
+# Trap SIGINT (Ctrl+C) and call cleanup()
+trap cleanup SIGINT
+
+# Infinite loop
+while true; do 
+	echo "Running: ${EXECUTABLE}"
+	./${EXECUTABLE}
+   
+	if [ $? -ne 0 ]; then 
+		echo "Executable exited with an error."
+		break
+	fi
+   
+	if [ -f "*.STOPPED*" ]; then
+		echo "Stop file found. Exiting loop."
+		break
+	fi
+   
+   
+	echo "Sleeping for ${DELAY} seconds..."
+	sleep ${DELAY}
+   
+done

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -7,6 +7,7 @@ In most scenarios you will need to perform a few configuration tasks:
 
 ## Setting the configuration properties
 Update the `conf/CollectCDCStats.properties` file with your favourite editor and set the properties to reflect your environment.
+Update the `conf/DatastoresAndSubscriptions.properties` file with your favourite editor and set the properties to reflect your environment.
 
 ### Access Server properties
 * CDC\_AS\_HOME: Home (main) directory of the Access Server or Management Console. This directory must have a `lib` subdirectory that holds the CHCCLP jar files and a directory with the Java Runtime Engine that will be used for the utility. If your directory path contains blanks or other special characters, please enclose the path in double quotes ("). If you run the utility on Windows, you would typically have to enclose the path in double quotes. Example: `CDC_AS_HOME="C:\Program Files (x86)\IBM\IS CDC MC 1133"`
@@ -56,3 +57,7 @@ If you wish to send alert messages for invalid or failed subscriptions, you need
 * mail.sender.password= Password or app-specific password of the sender email account  
 * mail.recipient.email= Recipient’s email address where alerts will be sent  
 
+# Email Mode
+* PER_DATASTORE – Use this mode if you require an alert email for each datastore individually, containing all inactive and failed subscriptions related to that specific datastore.
+
+* CONSOLIDATED – Use this mode if you require a single consolidated alert email that includes all datastores, listing all inactive and failed subscriptions under each datastore.

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -14,3 +14,7 @@ Once the tool has been configured, you can perform collect the statistics using 
 `CollectCDCStats.sh`
 
 The command connects to the Access Server and then the CDC_DB2 datastore. Subsequently, it retrieves the statistics for subscriptions S1, S2 and S3 and then writes them to the database specified in the properties file.
+
+## scheduled script
+
+For scheduled execution, use `CollectStats_Loop.sh`, which automatically re-triggers the process at the desired frequency. The frequency interval can be configured by adjusting the delay parameter in the loop script.

--- a/conf/CollectCDCStats.properties
+++ b/conf/CollectCDCStats.properties
@@ -69,6 +69,10 @@ com.ibm.replication.iidr.warehouse.logging.LogDatabase.dbSchema=CDCSTATS
 # usually the | character should do
 com.ibm.replication.iidr.warehouse.logging.LogCsv.csvSeparator=|
 
+# Email mode
+# Options: PER_DATASTORE or CONSOLIDATED
+email.mode=CONSOLIDATED
+
 # Email configuration
 mail.smtp.host=smtp.example.com
 mail.smtp.port=587

--- a/src/com/ibm/replication/iidr/utils/AlertEmailer.java
+++ b/src/com/ibm/replication/iidr/utils/AlertEmailer.java
@@ -53,7 +53,7 @@ public class AlertEmailer {
 
  // NEW: One email containing all datastores and their alerts
     public void sendConsolidatedEmail(Map<String, List<LogDatabase.SubAlert>> alertsByDatastore) {
-    	logger.debug("Preparing sendConsolidatedEmail");
+    //	logger.debug("Preparing sendConsolidatedEmail");
         if (alertsByDatastore == null || alertsByDatastore.isEmpty()) {
             logger.info("No failed/inactive subscriptions across all datastores in this cycle.");
             return;

--- a/src/com/ibm/replication/iidr/utils/AlertEmailer.java
+++ b/src/com/ibm/replication/iidr/utils/AlertEmailer.java
@@ -1,0 +1,100 @@
+package com.ibm.replication.iidr.utils;
+
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.mail.MessagingException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.ibm.replication.iidr.warehouse.logging.LogDatabase;
+
+public class AlertEmailer {
+	
+	private Settings settings;
+	static Logger logger;
+
+    // Constructor that accepts Settings as an argument
+    public AlertEmailer(Settings settings) {
+        this.settings = settings;
+		logger =LogManager.getLogger();
+    }
+	
+	 // Method to send email for datastore
+    public void sendEmailForDatastore(String dataStore, List<LogDatabase.SubAlert> alerts) {
+        if (alerts == null || alerts.isEmpty()) {
+            logger.info("No failed/inactive subscriptions for datastore " + dataStore + " in this cycle.");
+            return;
+        }
+
+        String subject = "[CDC] " + dataStore + " subscriptions with issues (" + alerts.size() + ")";
+        StringBuilder body = new StringBuilder();
+        body.append("Datastore: ").append(dataStore).append('\n');
+        body.append("Collected at: ").append(new Timestamp(System.currentTimeMillis())).append("\n\n");
+        body.append("Subscription                           State       Last Seen (COLLECT_TS)\n");
+        body.append("-------------------------------------------------------------------------------\n");
+
+        for (LogDatabase.SubAlert alert : alerts) {
+            body.append(String.format("%-40s %-12s %s%n", alert.subscription, alert.state, alert.ts));
+        }
+
+        // Send the email using an existing utility (MailUtil or custom method)
+        try {
+			MailUtil.sendEmail(settings, subject, body.toString());
+		} catch (MessagingException e) {
+			// TODO Auto-generated catch block
+			logger.error("Failed to send email notification: " + e.getMessage());		}
+    }
+
+ // NEW: One email containing all datastores and their alerts
+    public void sendConsolidatedEmail(Map<String, List<LogDatabase.SubAlert>> alertsByDatastore) {
+    	logger.debug("Preparing sendConsolidatedEmail");
+        if (alertsByDatastore == null || alertsByDatastore.isEmpty()) {
+            logger.info("No failed/inactive subscriptions across all datastores in this cycle.");
+            return;
+        }
+
+        // Count totals and sort datastores for a stable, readable output
+        List<String> datastores = new ArrayList<>(alertsByDatastore.keySet());
+        Collections.sort(datastores);
+
+        int totalAlerts = 0;
+        for (String ds : datastores) {
+            List<LogDatabase.SubAlert> list = alertsByDatastore.get(ds);
+            if (list != null) totalAlerts += list.size();
+        }
+
+        String subject = "[CDC] Subscriptions with issues across datastores (" + totalAlerts + " alerts, " +
+                         datastores.size() + " datastores)";
+
+        StringBuilder body = new StringBuilder();
+        body.append("Collected at: ").append(new Timestamp(System.currentTimeMillis())).append("\n\n");
+
+        for (String ds : datastores) {
+            List<LogDatabase.SubAlert> alerts = alertsByDatastore.get(ds);
+            if (alerts == null || alerts.isEmpty()) continue;
+
+            body.append("Datastore: ").append(ds).append("  (").append(alerts.size()).append(" issues)\n\n");
+            body.append("Subscription                           State       Last Seen (COLLECT_TS)\n");
+            body.append("-------------------------------------------------------------------------------\n");
+            // Optional: sort alerts by time (latest first)
+            alerts.sort((a, b) -> b.ts.compareTo(a.ts));
+            for (LogDatabase.SubAlert alert : alerts) {
+                body.append(String.format("%-40s %-12s %s%n", alert.subscription, alert.state, alert.ts));
+            }
+            body.append("\n");
+        }
+
+        try {
+            MailUtil.sendEmail(settings, subject, body.toString());
+            logger.info("Consolidated alert email sent. Total alerts: " + totalAlerts + ", datastores: " + datastores.size());
+        } catch (MessagingException e) {
+            logger.error("Failed to send consolidated email notification: " + e.getMessage());
+        }
+    }
+}

--- a/src/com/ibm/replication/iidr/utils/MailUtil.java
+++ b/src/com/ibm/replication/iidr/utils/MailUtil.java
@@ -34,7 +34,10 @@ public class MailUtil {
     // Create and send email
     MimeMessage message = new MimeMessage(session);
     message.setFrom(new InternetAddress(senderEmail));
-    message.addRecipient(Message.RecipientType.TO, new InternetAddress(recipientEmail));
+     String[] recipientEmails = recipientEmail.split(","); // Assuming recipientEmail contains comma-separated addresses
+    for (String email : recipientEmails) {
+        message.addRecipient(Message.RecipientType.TO, new InternetAddress(email.trim()));
+    }
     message.setSubject(subject);
     message.setText(body);
 

--- a/src/com/ibm/replication/iidr/utils/MailUtil.java
+++ b/src/com/ibm/replication/iidr/utils/MailUtil.java
@@ -32,14 +32,9 @@ public class MailUtil {
     });
 
     // Create and send email
-	// MimeMessage holds the actual email content
     MimeMessage message = new MimeMessage(session);
     message.setFrom(new InternetAddress(senderEmail));
-    String[] recipientEmails = recipientEmail.split(","); // Assuming recipientEmail contains comma-separated addresses
-    for (String email : recipientEmails) {
-        message.addRecipient(Message.RecipientType.TO, new InternetAddress(email.trim()));
-    }
-
+    message.addRecipient(Message.RecipientType.TO, new InternetAddress(recipientEmail));
     message.setSubject(subject);
     message.setText(body);
 

--- a/src/com/ibm/replication/iidr/utils/SubscriptionAlert.java
+++ b/src/com/ibm/replication/iidr/utils/SubscriptionAlert.java
@@ -1,0 +1,56 @@
+package com.ibm.replication.iidr.utils;
+
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+import com.ibm.replication.iidr.warehouse.logging.LogDatabase.SubAlert;
+
+public class SubscriptionAlert {
+
+	static Logger logger;
+	
+    private static final SubscriptionAlert INSTANCE = new SubscriptionAlert();
+
+	public final Map<String, List<SubAlert>> pendingAlertsByDS = new ConcurrentHashMap<String, List<SubAlert>>();
+     
+	private SubscriptionAlert() {
+	
+       logger= LogManager.getLogger();
+
+	}
+
+    public static SubscriptionAlert getInstance() {
+        return INSTANCE;
+    }
+	// Give getter if datastore received sent those respective alerts
+	public List<SubAlert> getAlertsForDatastore(String datastore) {
+		return pendingAlertsByDS.get(datastore);
+	}
+
+	// Remove the alerts once sent
+	public void removeAlertsForDatastore(String datastore) {
+		pendingAlertsByDS.remove(datastore);
+	}
+	
+	public Map<String, List<SubAlert>> snapshotAndClear() {
+        Map<String, List<SubAlert>> snapshot = new HashMap<>();
+        for (Map.Entry<String, List<SubAlert>> e : pendingAlertsByDS.entrySet()) {
+            // copy each list to avoid mutation during send
+        	logger.debug("Inside snapshots and clear");
+        	if(e.getValue() != null && !e.getValue().isEmpty()) {
+        		snapshot.put(e.getKey(), new ArrayList<>(e.getValue()));
+        	}
+            
+        }
+        // clear after copying
+        pendingAlertsByDS.clear();
+        return snapshot;
+    }
+}

--- a/src/com/ibm/replication/iidr/warehouse/CollectCDCStats.java
+++ b/src/com/ibm/replication/iidr/warehouse/CollectCDCStats.java
@@ -858,21 +858,21 @@ public class CollectCDCStats {
 			}
 			
 		}
-		logger.debug("Before if clause main");
+		//logger.debug("Before if clause main");
 		if ("CONSOLIDATED".equalsIgnoreCase(settings.getString("email.mode")) 
 		        && settings.getString("mail.smtp.host") != null 
 		        && !settings.getString("mail.smtp.host").isEmpty()) {
 
 			// Send consolidated email if there are any alerts
-			logger.debug("Before alerts clause main");
+			//logger.debug("Before alerts clause main");
 			SubscriptionAlert alerts = SubscriptionAlert.getInstance();
 			
-			logger.debug("Before emailer clause main");
+			//logger.debug("Before emailer clause main");
 			AlertEmailer emailer = new AlertEmailer(settings);
 			logger.debug("Before snapshot clause main");
 			Map<String, List<LogDatabase.SubAlert>> toSend = alerts
 					.snapshotAndClear();
-			logger.debug("Before sendConsolidatedEmail clause main");
+			//logger.debug("Before sendConsolidatedEmail clause main");
 			emailer.sendConsolidatedEmail(toSend);
 		}
 

--- a/src/com/ibm/replication/iidr/warehouse/CollectCDCStats.java
+++ b/src/com/ibm/replication/iidr/warehouse/CollectCDCStats.java
@@ -36,7 +36,9 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.io.File;
@@ -56,11 +58,15 @@ import com.ibm.replication.cdc.scripting.EmbeddedScript;
 import com.ibm.replication.cdc.scripting.EmbeddedScriptException;
 import com.ibm.replication.cdc.scripting.Result;
 import com.ibm.replication.cdc.scripting.ResultStringTable;
+import com.ibm.replication.iidr.utils.AlertEmailer;
 import com.ibm.replication.iidr.utils.Bookmarks;
 import com.ibm.replication.iidr.utils.MetricsDefinitions;
 import com.ibm.replication.iidr.utils.Settings;
+import com.ibm.replication.iidr.utils.SubscriptionAlert;
 import com.ibm.replication.iidr.utils.Timer;
 import com.ibm.replication.iidr.utils.Utils;
+import com.ibm.replication.iidr.warehouse.logging.LogDatabase;
+import com.ibm.replication.iidr.warehouse.logging.LogDatabase.SubAlert;
 
 public class CollectCDCStats {
 
@@ -70,7 +76,7 @@ public class CollectCDCStats {
 	private Result result;
 	private ResultStringTable subscriptionList;
 
-	private Settings settings;
+	private static Settings settings;
 	private Bookmarks bookmarks;
 	private MetricsDefinitions metricsDefinitions;
 
@@ -145,6 +151,10 @@ public class CollectCDCStats {
 		timer = new Timer(settings);
 		new Thread(timer).start();
 
+		AlertEmailer alertMailer = new AlertEmailer(settings);
+
+		SubscriptionAlert alert = SubscriptionAlert.getInstance();
+
 		// Create a script object to be used to execute CHCCLP commands
 		script = new EmbeddedScript();
 		try {
@@ -159,7 +169,15 @@ public class CollectCDCStats {
 				processSubscriptions();
 				// Always sleep for 1 second, the frequency of the operations is
 				// depicted in the properties file
-			
+				if ("PER_DATASTORE".equalsIgnoreCase(settings.getString("email.mode")) && settings.getString("mail.smtp.host") != null 
+				        && !settings.getString("mail.smtp.host").isEmpty()) {
+
+					List<SubAlert> alertssub = alert
+							.getAlertsForDatastore(parms.datastore);
+					alertMailer.sendEmailForDatastore(parms.datastore,
+							alertssub);
+					alert.removeAlertsForDatastore(parms.datastore);
+				}
 				// Sleep for the specified interval
 				Thread.sleep(1000);
 				keepOn = false;
@@ -821,14 +839,14 @@ public class CollectCDCStats {
 						+ File.separatorChar + parms.loggingConfigurationFile);
 		Logger logger = LogManager.getLogger();
 
-		
 		// Collect the statistics
 		for (String datastore : parms.datastoreList) {
 			logger.info("Processing datastore: " + datastore);
 
 			// Set the current datastore in the parameters
 			parms.datastore = datastore;
-		    parms.subscriptionList = parms.datastoreSubscriptionsMap.get(datastore);
+			parms.subscriptionList = parms.datastoreSubscriptionsMap
+					.get(datastore);
 
 			try {
 				new CollectCDCStats(parms);
@@ -838,8 +856,26 @@ public class CollectCDCStats {
 				logger.error("Error while collecting statistics from CDC: "
 						+ e.getMessage());
 			}
+			
 		}
-		
+		logger.debug("Before if clause main");
+		if ("CONSOLIDATED".equalsIgnoreCase(settings.getString("email.mode")) 
+		        && settings.getString("mail.smtp.host") != null 
+		        && !settings.getString("mail.smtp.host").isEmpty()) {
+
+			// Send consolidated email if there are any alerts
+			logger.debug("Before alerts clause main");
+			SubscriptionAlert alerts = SubscriptionAlert.getInstance();
+			
+			logger.debug("Before emailer clause main");
+			AlertEmailer emailer = new AlertEmailer(settings);
+			logger.debug("Before snapshot clause main");
+			Map<String, List<LogDatabase.SubAlert>> toSend = alerts
+					.snapshotAndClear();
+			logger.debug("Before sendConsolidatedEmail clause main");
+			emailer.sendConsolidatedEmail(toSend);
+		}
+
 		logger.info("Processing completed");
 	}
 }

--- a/src/com/ibm/replication/iidr/warehouse/logging/LogDatabase.java
+++ b/src/com/ibm/replication/iidr/warehouse/logging/LogDatabase.java
@@ -229,29 +229,6 @@ public class LogDatabase extends LogInterface {
 			con.commit();
 	}
 
-	/**
-	 * Sends an email notification for inactive subscription status.
-	 */
-//	private void sendEmailNotification(String dataStore, String subscriptionName,Timestamp collectTimestamp, String subscriptionState) {
-//	    String subject = "Subscription Status Alert: "+ subscriptionState;
-//	    String body = "The subscription '" + subscriptionName + "' for data store '" + dataStore
-//	            + "' is currently in '" + subscriptionState + "' state.";
-//	 
-//
-//	    try {
-//	        // Use JavaMail API or any other mail utility to send the email
-//	    	if(settings.getString("mail.smtp.host")== null || settings.getString("mail.smtp.host").isEmpty()) {
-//	    		logger.warn("SMTP parameters are not set. Email notification will not be sent.");
-//	            return;
-//	    	}
-//	        MailUtil.sendEmail(settings, subject, body);
-//	        // method uses the settings object from LogInterface 
-//	       // This settings object contains configuration details (e.g., email server, credentials, etc.) required for sending emails.
-//	        logger.info("Email notification sent for subscription: " + subscriptionName);
-//	    } catch (Exception e) {
-//	        logger.error("Failed to send email notification: " + e.getMessage());
-//	    }
-//	}
 
 	/**
 	 * Final processing (disconnect from the database)

--- a/src/com/ibm/replication/iidr/warehouse/logging/LogDatabase.java
+++ b/src/com/ibm/replication/iidr/warehouse/logging/LogDatabase.java
@@ -7,10 +7,13 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
 import java.util.Properties;
 
 import com.ibm.replication.iidr.utils.Settings;
-import com.ibm.replication.iidr.utils.MailUtil;
+import com.ibm.replication.iidr.utils.SubscriptionAlert;
 
 public class LogDatabase extends LogInterface {
 
@@ -26,13 +29,16 @@ public class LogDatabase extends LogInterface {
 	String dbDriverName;
 	String dbSchema;
 
-	public LogDatabase(Settings settings)
-			throws IllegalAccessException, InstantiationException, ClassNotFoundException, IOException {
+	public LogDatabase(Settings settings) throws IllegalAccessException,
+			InstantiationException, ClassNotFoundException, IOException {
 		super(settings);
-		dbUserName = settings.getString(this.getClass().getName() + ".dbUserName");
-		dbPassword = settings.getEncryptedString(this.getClass().getName() + ".dbPassword");
+		dbUserName = settings
+				.getString(this.getClass().getName() + ".dbUserName");
+		dbPassword = settings
+				.getEncryptedString(this.getClass().getName() + ".dbPassword");
 		dbUrl = settings.getString(this.getClass().getName() + ".dbUrl");
-		dbDriverName = settings.getString(this.getClass().getName() + ".dbDriverName");
+		dbDriverName = settings
+				.getString(this.getClass().getName() + ".dbDriverName");
 		dbSchema = settings.getString(this.getClass().getName() + ".dbSchema");
 
 		connect();
@@ -48,19 +54,24 @@ public class LogDatabase extends LogInterface {
 	 * @throws InstantiationException
 	 * @throws ClassNotFoundException
 	 */
-	public void connect() throws IOException, IllegalAccessException, InstantiationException, ClassNotFoundException {
+	public void connect() throws IOException, IllegalAccessException,
+		InstantiationException, ClassNotFoundException {
 		try {
 			Properties props = new Properties();
 			props.put("user", dbUserName);
 			props.put("password", dbPassword);
-			logger.debug("Database URL: " + dbUrl + ", driver: " + dbDriverName);
+			logger.debug(
+					"Database URL: " + dbUrl + ", driver: " + dbDriverName);
 			Class.forName(dbDriverName).newInstance();
 			con = DriverManager.getConnection(dbUrl, props);
 
-			logger.debug("Connecting to url : " + dbUrl + " using user name " + dbUserName);
+			logger.debug("Connecting to url : " + dbUrl + " using user name "
+					+ dbUserName);
 			DatabaseMetaData dbmd = con.getMetaData();
-			logger.debug("DatabaseProductName: " + dbmd.getDatabaseProductName());
-			logger.debug("DatabaseProductVersion: " + dbmd.getDatabaseProductVersion());
+			logger.debug(
+					"DatabaseProductName: " + dbmd.getDatabaseProductName());
+			logger.debug("DatabaseProductVersion: "
+					+ dbmd.getDatabaseProductVersion());
 			// Disable auto-commit, this should be done in the harden() method
 			logger.debug("Disabling auto-commit");
 			con.setAutoCommit(false);
@@ -71,7 +82,8 @@ public class LogDatabase extends LogInterface {
 			logger.error(esql.toString());
 			disconnect();
 		} catch (Exception e) {
-			logger.error("Connecting to database failed, error: " + e.toString());
+			logger.error(
+					"Connecting to database failed, error: " + e.toString());
 		}
 	}
 
@@ -85,7 +97,8 @@ public class LogDatabase extends LogInterface {
 			try {
 				con.close();
 			} catch (SQLException ignore) {
-				logger.debug("Error while closing connection to database: " + ignore.getMessage());
+				logger.debug("Error while closing connection to database: "
+						+ ignore.getMessage());
 			}
 		}
 	}
@@ -96,14 +109,17 @@ public class LogDatabase extends LogInterface {
 	 * @throws SQLException
 	 */
 	@Override
-	public void logSubscriptionStatus(String dataStore, String subscriptionName, Timestamp collectTimestamp,
-			String subscriptionState) throws SQLException {
+	public void logSubscriptionStatus(String dataStore, String subscriptionName,
+		Timestamp collectTimestamp, String subscriptionState)
+		throws SQLException {
 		// Only try to insert the status if the connection has been established
 		if (con != null) {
 			// Prepare statement if this is the first time
 			if (insertSubStatus == null)
-				insertSubStatus = con.prepareStatement("insert into " + dbSchema + ".CDC_SUB_STATUS "
-						+ "(SRC_DATASTORE,SUBSCRIPTION,COLLECT_TS,SUBSCRIPTION_STATUS) " + "VALUES (?,?,?,?)");
+				insertSubStatus = con.prepareStatement("insert into " + dbSchema
+						+ ".CDC_SUB_STATUS "
+						+ "(SRC_DATASTORE,SUBSCRIPTION,COLLECT_TS,SUBSCRIPTION_STATUS) "
+						+ "VALUES (?,?,?,?)");
 
 			// Write the subscription status into the table
 			insertSubStatus.setString(1, dataStore);
@@ -111,9 +127,27 @@ public class LogDatabase extends LogInterface {
 			insertSubStatus.setTimestamp(3, collectTimestamp);
 			insertSubStatus.setString(4, subscriptionState);
 			insertSubStatus.execute();
-			logger.debug("Subsription State: "+subscriptionState);
-			if ("INACTIVE".equalsIgnoreCase(subscriptionState) || "FAILED".equalsIgnoreCase(subscriptionState)) {
-				sendEmailNotification(dataStore, subscriptionName, collectTimestamp, subscriptionState);
+			logger.debug("Subsription State: " + subscriptionState);
+
+			
+			String smtphost = settings.getString("mail.smtp.host", null);
+			logger.debug("SMTP Host: " + smtphost);
+			if (smtphost != null && !smtphost.isEmpty()) {
+				SubscriptionAlert subsAlert = SubscriptionAlert.getInstance();
+				if ("INACTIVE".equalsIgnoreCase(subscriptionState)
+						|| "FAILED".equalsIgnoreCase(subscriptionState)) {
+					List<SubAlert> alerts = subsAlert.pendingAlertsByDS
+							.get(dataStore);
+					if (alerts == null) {
+						alerts = new ArrayList<SubAlert>();
+						subsAlert.pendingAlertsByDS.put(dataStore, alerts);
+					}
+					alerts.add(new SubAlert(subscriptionName, subscriptionState,
+							collectTimestamp));
+				}
+			}
+			else {
+				logger.debug("Skipping email notification as SMTP host is not configured.");
 			}
 		}
 	}
@@ -122,12 +156,14 @@ public class LogDatabase extends LogInterface {
 	 * Logs the metrics into the database
 	 */
 	@Override
-	public void logMetrics(String dataStore, String subscriptionName, Timestamp collectTimestamp,
-			String metricSourceTarget, int metricID, long metricValue) throws SQLException {
+	public void logMetrics(String dataStore, String subscriptionName,
+		Timestamp collectTimestamp, String metricSourceTarget, int metricID,
+		long metricValue) throws SQLException {
 		// Only try to insert the status if the connection has been established
 		if (con != null) {
 			if (insertSubMetrics == null)
-				insertSubMetrics = con.prepareStatement("insert into " + dbSchema + ".CDC_STATS_ALL "
+				insertSubMetrics = con.prepareStatement("insert into "
+						+ dbSchema + ".CDC_STATS_ALL "
 						+ "(SRC_DATASTORE,SUBSCRIPTION,COLLECT_TS,SRC_TGT,METRIC_ID,METRIC_VALUE) "
 						+ "VALUES (?,?,?,?,?,?)");
 
@@ -139,6 +175,7 @@ public class LogDatabase extends LogInterface {
 			insertSubMetrics.setInt(5, metricID);
 			insertSubMetrics.setLong(6, metricValue);
 			insertSubMetrics.execute();
+
 		}
 	}
 
@@ -148,12 +185,14 @@ public class LogDatabase extends LogInterface {
 	 * @throws SQLException
 	 */
 	@Override
-	public void logEvent(String dataStore, String subscriptionName, String sourceTarget, String eventIDString,
-			String eventType, String eventTimestampString, String eventMessage) throws SQLException {
+	public void logEvent(String dataStore, String subscriptionName,
+		String sourceTarget, String eventIDString, String eventType,
+		String eventTimestampString, String eventMessage) throws SQLException {
 		// Only try to insert the status if the connection has been established
 		if (con != null) {
 			if (insertEvents == null)
-				insertEvents = con.prepareStatement("insert into " + dbSchema + ".CDC_EVENTS "
+				insertEvents = con.prepareStatement("insert into " + dbSchema
+						+ ".CDC_EVENTS "
 						+ "(SRC_DATASTORE,SUBSCRIPTION,SRC_TGT,EVENT_ID,EVENT_TYPE,EVENT_TIMESTAMP,EVENT_MESSAGE) "
 						+ "VALUES (?,?,?,?,?,?,?)");
 		}
@@ -163,7 +202,8 @@ public class LogDatabase extends LogInterface {
 		try {
 			eventID = Integer.parseInt(eventIDString);
 		} catch (NumberFormatException e) {
-			logger.error("Error converting event ID " + eventIDString + " to numeric, will be set to 0");
+			logger.error("Error converting event ID " + eventIDString
+					+ " to numeric, will be set to 0");
 		}
 
 		// Try to convert event timestamp to Timestamp
@@ -188,31 +228,31 @@ public class LogDatabase extends LogInterface {
 		if (con != null)
 			con.commit();
 	}
-		
+
 	/**
 	 * Sends an email notification for inactive subscription status.
 	 */
-	private void sendEmailNotification(String dataStore, String subscriptionName,Timestamp collectTimestamp, String subscriptionState) {
-	    String subject = "Subscription Status Alert: "+ subscriptionState;
-	    String body = "The subscription '" + subscriptionName + "' for data store '" + dataStore
-	            + "' is currently in '" + subscriptionState + "' state.";
-	 
+//	private void sendEmailNotification(String dataStore, String subscriptionName,Timestamp collectTimestamp, String subscriptionState) {
+//	    String subject = "Subscription Status Alert: "+ subscriptionState;
+//	    String body = "The subscription '" + subscriptionName + "' for data store '" + dataStore
+//	            + "' is currently in '" + subscriptionState + "' state.";
+//	 
+//
+//	    try {
+//	        // Use JavaMail API or any other mail utility to send the email
+//	    	if(settings.getString("mail.smtp.host")== null || settings.getString("mail.smtp.host").isEmpty()) {
+//	    		logger.warn("SMTP parameters are not set. Email notification will not be sent.");
+//	            return;
+//	    	}
+//	        MailUtil.sendEmail(settings, subject, body);
+//	        // method uses the settings object from LogInterface 
+//	       // This settings object contains configuration details (e.g., email server, credentials, etc.) required for sending emails.
+//	        logger.info("Email notification sent for subscription: " + subscriptionName);
+//	    } catch (Exception e) {
+//	        logger.error("Failed to send email notification: " + e.getMessage());
+//	    }
+//	}
 
-	    try {
-	        // Use JavaMail API or any other mail utility to send the email
-	    	if(settings.getString("mail.smtp.host")== null || settings.getString("mail.smtp.host").isEmpty()) {
-	    		logger.warn("SMTP parameters are not set. Email notification will not be sent.");
-	            return;
-	    	}
-	        MailUtil.sendEmail(settings, subject, body);
-	        // method uses the settings object from LogInterface 
-	       // This settings object contains configuration details (e.g., email server, credentials, etc.) required for sending emails.
-	        logger.info("Email notification sent for subscription: " + subscriptionName);
-	    } catch (Exception e) {
-	        logger.error("Failed to send email notification: " + e.getMessage());
-	    }
-	}
-	
 	/**
 	 * Final processing (disconnect from the database)
 	 */
@@ -220,6 +260,18 @@ public class LogDatabase extends LogInterface {
 	public void finish() {
 		logger.debug("Finalizing processing for logging to database");
 		disconnect();
+	}
+
+	public static final class SubAlert {
+		public final String subscription;
+		public final String state;
+		public final Timestamp ts;
+
+		SubAlert(String subscription, String state, Timestamp ts) {
+			this.subscription = subscription;
+			this.state = state;
+			this.ts = ts;
+		}
 	}
 
 }


### PR DESCRIPTION
**Business Problem:**
Currently, an email is sent for each failed or inactive subscription. In real-world scenarios, where there may be over 3,000 subscriptions, this approach results in a large volume of emails, quickly filling up mailboxes and making it difficult to monitor effectively.

**Proposed Solution:**
I have introduced a customizable feature with two modes of operation:

_PER_DATASTORE_ – Sends a separate alert email for each datastore, containing all inactive and failed subscriptions related to that datastore.

_CONSOLIDATED_ – Sends a single consolidated alert email covering all datastores, listing all inactive and failed subscriptions under each datastore.

This solution helps reduce email volume while still providing visibility into failed and inactive subscriptions.

**Additional Feature:**
A scheduling script has been added to automatically re-trigger the process at a configurable frequency. The interval can be adjusted by modifying the delay parameter in the loop script, allowing for flexible and automated monitoring.